### PR TITLE
Make benchmarks pass based on 'All' or 'Any' mode

### DIFF
--- a/src/serde_types.in.rs
+++ b/src/serde_types.in.rs
@@ -1,10 +1,10 @@
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 enum Mode {
     All,
     Any,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 struct AuditStep {
     run: String,
     expect: Option<String>,


### PR DESCRIPTION
Every benchmark in an audit spec has a field 'Mode' which can have
the value 'All' (default) or 'Any'. If the value is 'All' then all
audit commands given in the 'run' steps must pass. If the value is
'Any', then the benchmark as a whole passes when any one of them
passes.